### PR TITLE
Amend the overview for the Anonymous Appointment Search section

### DIFF
--- a/patient-portal-api/anonymous-appointment-search/anonymous-appointment-search.markdown
+++ b/patient-portal-api/anonymous-appointment-search/anonymous-appointment-search.markdown
@@ -8,6 +8,8 @@ parent: Patient Portal API
 # Anonymous Appointment Search
 
 
-This section provides methods for making anonymous (i.e. not authenticated) appointment searches. The methods are deliberately similar to the appointment search API documented in section 9 ‘Appointments’.
+This section provides methods for making anonymous (i.e. not authenticated) appointment searches. The methods are deliberately similar to the appointment search API documented in [Appointments](../appointments/appointments.markdown), but in these methods the `payer-type` parameter is expected to be a charge-band sign-up code. One or more charge-bands must be pre-configured in Meddbase to allow online sign-up and assigned a code before these methods can be used.
 
-Each method in this section needs the client to provide the ASP.NET_SessionId key in a cookie (see [Login](../authentication/login)).
+Methods in this section do not require a session id to be provided.
+
+The results from an anonymous search can be used with the methods in [Anonymous Appointment Booking](../anonymous-appointment-booking/anonymous-appointment-booking.markdown) to book an appointment quickly without dealing with the standard [RegisterPatient](../authentication/registerpatient) process.


### PR DESCRIPTION
Remove the requirement for a session id and explain how to use the results.

Closes #19 